### PR TITLE
update README, how do I run this repo?

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -3,6 +3,7 @@ process.env.VUE_APP_NAME = require('./package.json').name || 'vue'
 module.exports = {
     // options...
     devServer: {
-        disableHostCheck: true
+        disableHostCheck: true,
+        proxy: "http://localhost:3000"
     }
 }


### PR DESCRIPTION
had to add this to get around CORS: https://cli.vuejs.org/config/#devserver-proxy

Maybe there's a different method?


I run:
```sh
account-merge $: yarn run serve
# ...running on http://localhost:8080

# ...in another session
xapp-proxy-for-xumm-api $: yarn run serve
# ...running on http://localhost:3000
```
Using the default port of `:3000` when using [XRPL-Labs/xapp-proxy-for-xumm-api](https://github.com/XRPL-Labs/xapp-proxy-for-xumm-api) with `yarn run serve`